### PR TITLE
Fix sed expression, as 'poetry debug' output has changed

### DIFF
--- a/poetry.zsh
+++ b/poetry.zsh
@@ -14,7 +14,7 @@ _zp_check_poetry_venv() {
   fi
   if [[ -f pyproject.toml ]] \
       && [[ "${PWD}" != "${_zp_current_project}" ]]; then
-    venv="$(command poetry debug:info 2>/dev/null | sed -n "s/\ *\* Path:\ *\(.*\)/\1/p")"
+    venv="$(command poetry debug 2>/dev/null | sed -n "s/Path:\ *\(.*\)/\1/p")"
     if [[ -d "$venv" ]] && [[ "$venv" != "$VIRTUAL_ENV" ]]; then
       source "$venv"/bin/activate || return $?
       _zp_current_project="${PWD}"


### PR DESCRIPTION
Looks like `poetry debug:info` no longer exists and instead is now just `poetry debug`.

The output of the command has also changed, thus `command poetry debug:info 2>/dev/null | sed -n "s/\ *\* Path:\ *\(.*\)/\1/p"` was always empty, effectively never activating any venv. What is more, it also broke `poetry shell`.