### PR TITLE
Fix venv path extraction for Poetry >v0.12.17

### DIFF
--- a/poetry.zsh
+++ b/poetry.zsh
@@ -14,7 +14,7 @@ _zp_check_poetry_venv() {
   fi
   if [[ -f pyproject.toml ]] \
       && [[ "${PWD}" != "${_zp_current_project}" ]]; then
-    venv="$(command poetry debug 2>/dev/null | sed -n "s/Path:\ *\(.*\)/\1/p")"
+    venv="$(command poetry debug:info 2>/dev/null | sed -n "s/\ \*\ Path:\ *\(.*\)/\1/p")"
     if [[ -d "$venv" ]] && [[ "$venv" != "$VIRTUAL_ENV" ]]; then
       source "$venv"/bin/activate || return $?
       _zp_current_project="${PWD}"


### PR DESCRIPTION
I recognized that this plugin was not working anymore. I turned out that is was caused due to an update of Poetry. This PR fixes this issue. Unhappily it is not backward compatible with older versions. Such would require much more overhead. But Poetry is not yet stable in general. So future interface changes are expected.