### PR TITLE
Fix directly switching between shells; remove override

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,8 @@
 Automatically activates virtual environments created by [Poetry] when
 changing to a project directory with a valid ``pyproject.toml``.
 
-Also patches ``poetry shell`` to work more reliably, especially in
-environments using [pyenv]. See [sdispater/poetry#571][i571] and
-[sdispater/poetry#497][i497] for more information.
-
 [Poetry]: https://poetry.eustace.io/
 [pyenv]: https://github.com/pyenv/pyenv
-[i571]: https://github.com/sdispater/poetry/issues/571
-[i497]: https://github.com/sdispater/poetry/issues/497
 
 
 ## Install
@@ -33,7 +27,3 @@ Download and `source poetry.zsh`.
   changing directories.
 * `ZSH_POETRY_AUTO_DEACTIVATE` (default: `1`): if set, automatically
   deactivates virtual environments when moving out of project directories.
-* `ZSH_POETRY_OVERRIDE_SHELL` (default: `1`): if set, replaces
-  ``poetry shell`` with a call to activate the virtualenv directly,
-  which circumvents Poetry's (currently) problematic behavior when trying
-  to activate a shell in some environments.

--- a/poetry.zsh
+++ b/poetry.zsh
@@ -14,7 +14,7 @@ _zp_check_poetry_venv() {
   fi
   if [[ -f pyproject.toml ]] \
       && [[ "${PWD}" != "${_zp_current_project}" ]]; then
-    venv="$(command poetry debug 2>/dev/null | sed -n "s/Path:\ *\(.*\)/\1/p")"
+    venv="$(command poetry env list --full-path | sed "s/ .*//" | head -1)"
     if [[ -d "$venv" ]] && [[ "$venv" != "$VIRTUAL_ENV" ]]; then
       source "$venv"/bin/activate || return $?
       _zp_current_project="${PWD}"
@@ -35,18 +35,5 @@ add-zsh-hook chpwd _zp_check_poetry_venv
 poetry-shell() {
   _zp_check_poetry_venv
 }
-
-if [[ -n $ZSH_POETRY_OVERRIDE_SHELL ]]; then
-  poetry() {
-    if [[ $1 == "shell" ]]; then
-      _zp_check_poetry_venv || (
-        echo 'pyproject.toml file not found' >&2;
-        exit 1
-      )
-      return $?
-    fi
-    command poetry "$@"
-  }
-fi
 
 [[ -n $ZSH_POETRY_AUTO_ACTIVATE ]] && _zp_check_poetry_venv


### PR DESCRIPTION
* Using poetry debug to detect the virtual environment doesn't work when
  switching from one poetry project to another directly.  This is a
  major pain.
* ZSH_POETRY_OVERRIDE_SHELL is no longer necessary since the linked
  issues were closed in Poetry 1.0.