### PR TITLE
Add installation instructions for Oh My Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ Download and `source poetry.zsh`.
 ### zplug
 `zplug "darvid/zsh-poetry"`
 
+### Oh My Zsh
+
+```zsh
+git clone https://github.com/darvid/zsh-poetry $ZSH_CUSTOM/plugins/zsh-poetry
+```
+
+In your `~/.zshrc` add zsh-poetry to your plugins.
+
+```zsh
+plugins=(
+  ...
+  zsh-poetry
+  ...
+)
+```
 
 ## Configuration
 


### PR DESCRIPTION
Documentation follow-up to #9. Add instructions in `README.md` on how to install zsh-poetry if using Oh My Zsh.
