### PR TITLE
Activate when entering subdirs

### DIFF
--- a/poetry.zsh
+++ b/poetry.zsh
@@ -1,9 +1,16 @@
 #!/usr/bin/env zsh
 ZSH_POETRY_AUTO_ACTIVATE=${ZSH_POETRY_AUTO_ACTIVATE:-1}
 ZSH_POETRY_AUTO_DEACTIVATE=${ZSH_POETRY_AUTO_DEACTIVATE:-1}
-ZSH_POETRY_OVERRIDE_SHELL=${ZSH_POETRY_OVERRIDE_SHELL:-1}
 
 autoload -U add-zsh-hook
+
+find-in-parents() {
+  _parent=$(pwd)
+  while [[ ${_parent} != "" && ! -e ${_parent}/${1} ]]; do
+    _parent=${_parent%/*}
+  done
+  echo ${_parent}
+}
 
 _zp_current_project=
 
@@ -12,12 +19,13 @@ _zp_check_poetry_venv() {
   if [[ -z $VIRTUAL_ENV ]] && [[ -n "${_zp_current_project}" ]]; then
     _zp_current_project=
   fi
-  if [[ -f pyproject.toml ]] \
+  _proj_dir=$(find-in-parents pyproject.toml)
+  if [[ -n ${_proj_dir}  ]] \
       && [[ "${PWD}" != "${_zp_current_project}" ]]; then
     venv="$(command poetry env list --full-path | sed "s/ .*//" | head -1)"
     if [[ -d "$venv" ]] && [[ "$venv" != "$VIRTUAL_ENV" ]]; then
       source "$venv"/bin/activate || return $?
-      _zp_current_project="${PWD}"
+      _zp_current_project="${_proj_dir}"
       return 0
     fi
   elif [[ -n $VIRTUAL_ENV ]] \


### PR DESCRIPTION
Current version only activates the venv when you enter the project root directory, and not if you cd directly from outside the project into a subdirectory. 

This patch corrects that by checking for a pyproject.toml in the current pwd or any ancestor of it.